### PR TITLE
add: indexから場所の名前を取得した場合、最初から入力欄に入るようにした

### DIFF
--- a/static/js/googleMap.js
+++ b/static/js/googleMap.js
@@ -144,6 +144,7 @@ function NeighborhoodDiscovery(configuration) {
     mapOptions.scaleControlOptions = {position: google.maps.ControlPosition.LEFT};
     // 地図のタイプ(航空写真+ラベル付き)
     mapOptions.mapTypeId = google.maps.MapTypeId.HYBRID;
+    mapOptions.mapTypeControlOptions = {position: google.maps.ControlPosition.RIGHT_TOP};
     // gestureHandlingを"greedy"に変更
     mapOptions.gestureHandling = "greedy";
     widget.map = new google.maps.Map(widgetEl.querySelector('.map'), mapOptions);

--- a/templates/map.html
+++ b/templates/map.html
@@ -133,7 +133,7 @@
         <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" id="cityBtn" onclick="changeSearchType('city')">市単位</button>
         <form action="/country_info" method="get">
           <div class="mt-3">
-              <input class="form-control mx-auto w-auto mb-3" name="region" placeholder="入力" type="text">
+              <input class="form-control mx-auto w-auto mb-3" name="region" placeholder="入力" type="text" value="{{ nation_name }}">
               <input class="form-control mx-auto w-auto mb-3" name="placeID" placeholder="入力" type="text" hidden>
           </div>
           <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" type="submit">調べる</button>


### PR DESCRIPTION
# Pull Request

## レビュー担当者を割り当てる前の担当者のチェックリスト

<!-- Only complete tasks that are necessary -->

- [ ] PR を作るときは必ず自分をアサインすること
- [ ] 全ての TODO は完了できているか
- [ ] わかりやすい PR か
- [ ] PR の結果や変更を簡潔にシェアしてください
- [ ] 期限を厳守できたか

<!--
  <details>
    <summary>Example of Audits Report on 11/1/2019</summary>

  copy this [gist](https://gist.github.com/oladhari/ee8b153c2d8001ae6d87f8f9633bce1d) and drop it in this [viewer](https://googlechrome.github.io/lighthouse/viewer/) to read the report
  </details>

  <details>
    <summary>Example of Coverage Report on 11/1/2019</summary>

  </details>
-->

## PR を承認する前のレビュアーのチェックリスト

<!-- Only complete tasks that are necessary -->

- [ ] コードが最も効果的に記載されているか
- [ ] コードがタスクの完了を満たしているか

## 変更の概要

indexから国名を受け取った場合、入力欄に最初から国名が入力されている状態となるようにした。