### PR TITLE
fix: 位置によって国名や県名が取得できないバグを修正

### DIFF
--- a/static/css/sample.css
+++ b/static/css/sample.css
@@ -8,7 +8,7 @@
 /* Google mapを表示するコード */
 
 html, body {
-    height: 100%;
+    height: 80%;
     margin: 0;
     padding: 0;
   }
@@ -88,12 +88,12 @@ html, body {
   @media only screen and (max-width: 768px) {
     .neighborhood-discovery .panel {
       right: 0;
-      top: 50%;
+      top: 55%;
       width: unset;
     }
 
     .neighborhood-discovery .map {
-      bottom: 50%;
+      bottom: 45%;
       left: 0;
     }
   }

--- a/static/js/googleMap.js
+++ b/static/js/googleMap.js
@@ -532,7 +532,8 @@ function NeighborhoodDiscovery(configuration) {
 
     // 検索入力でオートコンプリートを設定する
     const autocomplete = new google.maps.places.Autocomplete(searchInputEl, {
-      types: ['establishment'],
+      // typesに何かしら指定すると、場所だけ選択できたりする。今回は国でも場所でも検索できるように空欄にした。
+      types: [],
       fields: [
         'place_id', 'name', 'types', 'geometry.location', 'formatted_address', 'photo', 'url', 'website', 'formatted_phone_number', 'opening_hours',
       ],

--- a/static/js/googleMap.js
+++ b/static/js/googleMap.js
@@ -269,11 +269,24 @@ function NeighborhoodDiscovery(configuration) {
         // Place を選択する処理
         void widget.selectPlaceById(place.placeId);
         // グローバル変数に代入
-        placeName = place.name
+        placeName = place.name;
+        // TODO function化
+        let placeAddress = place.address;
+        // 最初の空白の位置を取得
+        let spaceIndex = placeAddress.indexOf(" ");
+        // 最初の「、」の位置を取得
+        let commaIndex = placeAddress.indexOf("、");
+        let index = spaceIndex === -1 ? commaIndex : commaIndex === -1 ? spaceIndex : Math.min(spaceIndex, commaIndex);
+        let trimmedAddress = index === -1 ? placeAddress : placeAddress.substr(0, index);
+        // 空白以降の文字を削除した文字列
+        document.querySelector('input[name="country"]').value = trimmedAddress;
         // 取得した住所をformのinputにセットする
         document.querySelector('input[name="placeName"]').value = placeName;
+        // 都道府県検索の表示欄は同期できないので削除する
+        document.querySelector('input[name="region"]').value = "";
         // ストリートビューを表示する関数
         streetLocation(place.coords, widget.map);
+        // TODO ここまで
       });
     };
 
@@ -445,13 +458,27 @@ function NeighborhoodDiscovery(configuration) {
         if (panToMarker) {
           widget.map.panTo(place.coords);
         }
+        // TODO function化
+        placeName = place.name;
+        let placeAddress = place.address;
+        // 最初の空白の位置を取得
+        let spaceIndex = placeAddress.indexOf(" ");
+        // 最初の「、」の位置を取得
+        let commaIndex = placeAddress.indexOf("、");
+        let index = spaceIndex === -1 ? commaIndex : commaIndex === -1 ? spaceIndex : Math.min(spaceIndex, commaIndex);
+        let trimmedAddress = index === -1 ? placeAddress : placeAddress.substr(0, index);
+        // 空白と「、」以降の文字を削除した文字列
+        document.querySelector('input[name="country"]').value = trimmedAddress;
         // 検索機能やすでにピン立てしている場所をクリックした際にplaceIDを変える
         document.querySelector('input[name="placeID"]').value = placeId;
         // 住所がある場所の名前をセットする処理
         document.querySelector('input[name="placeName"]').value = place.name;
+        // 都道府県検索の表示欄は同期できないので削除する
+        document.querySelector('input[name="region"]').value = "";
         // サイドバーからもストリートビューを表示できるようにする関数
         streetLocation(place.coords, widget.map);
         showDetailsPanel(place);
+        // TODO ここまで
       };
 
       widget.fetchPlaceDetails(placeId, [
@@ -577,6 +604,7 @@ function geocodeLatLng(geocoder, map) {
 }
 
 // 場所をクリックすると調べるフォームに飛ぶ
+// TODO function化
 function clickNoArea(latlng, geocoder) {
   geocoder.geocode({ 'location': latlng }, function(results) {
     let clickAddress;
@@ -584,32 +612,82 @@ function clickNoArea(latlng, geocoder) {
         // 取得した住所をフォームのinputにセットする
         let addressComponents = results[0].address_components;
         let geometry = results[0].place_id;
+        let countryAddress;
         for (let i = 0; i < addressComponents.length; i++) {
           let types = addressComponents[i].types;
           // 国単位で調べたい場合
           if (searchType === 'country' && types.includes('country')) {
             // 取得した住所から国の部分だけ抽出する
             clickAddress = addressComponents[i].long_name;
-            break;
           } // 県単位で調べたい場合
           else if (searchType === 'prefecture' && types.includes('administrative_area_level_1')) {
             // 取得した住所から県の部分だけ抽出する
             clickAddress = addressComponents[i].long_name;
-            break;
           } // 市区町村単位で調べたい場合
           else if (searchType === 'city' && (types.includes('locality') || types.includes('administrative_area_level_2'))) {
             // 取得した住所から市区町村の部分だけ抽出する
             clickAddress = addressComponents[i].long_name;
+          }
+          // もしtypesがcountryだった場合、その国の名前を保存する
+          if (types.includes('country')) {
+            countryAddress = addressComponents[i].long_name;
+            // 全ての処理が終わったのでfor文を終了する
             break;
+          }
+        }
+        // resultsが0しかなかった(海など)場合のエラーを解決
+        if (results[1]) {
+          // もしundefinedだった場合の処理(アフリカ大陸あたりだとこちらでしか通らない)
+          if (countryAddress === undefined) {
+            // 取得した住所をフォームのinputにセットする
+            addressComponents = results[1].address_components;
+            geometry = results[1].place_id;
+            for (let i = 0; i < addressComponents.length; i++) {
+              let types = addressComponents[i].types;
+              // 国単位で調べたい場合
+              if (searchType === 'country' && types.includes('country')) {
+                // 取得した住所から国の部分だけ抽出する
+                clickAddress = addressComponents[i].long_name;
+              } // 県単位で調べたい場合
+              else if (searchType === 'prefecture' && types.includes('administrative_area_level_1')) {
+                // 取得した住所から県の部分だけ抽出する
+                clickAddress = addressComponents[i].long_name;
+              } // 市区町村単位で調べたい場合
+              else if (searchType === 'city' && (types.includes('locality') || types.includes('administrative_area_level_2'))) {
+                // 取得した住所から市区町村の部分だけ抽出する
+                clickAddress = addressComponents[i].long_name;
+              }
+              // もしtypesがcountryだった場合、その国の名前を保存する
+              if (types.includes('country')) {
+                countryAddress = addressComponents[i].long_name;
+                // 全ての処理が終わったのでfor文を終了する
+                break;
+              }
+            }
           }
         }
         // region_infoに送る用のPlaceIDをセットする
         document.querySelector('input[name="placeID"]').value = geometry;
         // 取得した住所をformのinputにセットする
-        document.querySelector('input[name="region"]').value = clickAddress;
+        // 上記らの処理でもundefinedだった場合の処理
+        if (clickAddress === undefined) {
+          // 取得した国をformのinputにセットする
+          document.querySelector('input[name="region"]').value = "見つかりません";
+        } else {
+          // 取得した国をformのinputにセットする
+          document.querySelector('input[name="region"]').value = clickAddress;
+        }
+        if (countryAddress === undefined) {
+          // 取得した国をformのinputにセットする
+          document.querySelector('input[name="country"]').value = "見つかりません";
+        } else {
+          // 取得した国をformのinputにセットする
+          document.querySelector('input[name="country"]').value = countryAddress;
+        }
       }
   })
 }
+// TODO ここまで
 
 // 位置情報の取得でエラーが出た場合
 function handleLocationError(browserHasGeolocation, infoWindow) {
@@ -630,7 +708,7 @@ function changeSearchType(type) {
   } else if (type === 'prefecture') {
     message = "県";
   } else if (type === 'city') {
-    message = "市区町村";
+    message = "市";
   }
   document.getElementById('searchTypeText').innerHTML = message;
 }

--- a/static/js/googleMap.js
+++ b/static/js/googleMap.js
@@ -270,23 +270,14 @@ function NeighborhoodDiscovery(configuration) {
         void widget.selectPlaceById(place.placeId);
         // グローバル変数に代入
         placeName = place.name;
-        // TODO function化
-        let placeAddress = place.address;
-        // 最初の空白の位置を取得
-        let spaceIndex = placeAddress.indexOf(" ");
-        // 最初の「、」の位置を取得
-        let commaIndex = placeAddress.indexOf("、");
-        let index = spaceIndex === -1 ? commaIndex : commaIndex === -1 ? spaceIndex : Math.min(spaceIndex, commaIndex);
-        let trimmedAddress = index === -1 ? placeAddress : placeAddress.substr(0, index);
-        // 空白以降の文字を削除した文字列
-        document.querySelector('input[name="country"]').value = trimmedAddress;
         // 取得した住所をformのinputにセットする
         document.querySelector('input[name="placeName"]').value = placeName;
         // 都道府県検索の表示欄は同期できないので削除する
         document.querySelector('input[name="region"]').value = "";
+        // 検索機能やすでにピン立てしている場所をクリックした際にplaceIDを変える
+        document.querySelector('input[name="placeID"]').value = place.placeId;
         // ストリートビューを表示する関数
         streetLocation(place.coords, widget.map);
-        // TODO ここまで
       });
     };
 
@@ -458,27 +449,24 @@ function NeighborhoodDiscovery(configuration) {
         if (panToMarker) {
           widget.map.panTo(place.coords);
         }
-        // TODO function化
         placeName = place.name;
         let placeAddress = place.address;
-        // 最初の空白の位置を取得
+        // 空白と「、」を検索し、それ以降の文字を削除した文字列
         let spaceIndex = placeAddress.indexOf(" ");
-        // 最初の「、」の位置を取得
         let commaIndex = placeAddress.indexOf("、");
         let index = spaceIndex === -1 ? commaIndex : commaIndex === -1 ? spaceIndex : Math.min(spaceIndex, commaIndex);
         let trimmedAddress = index === -1 ? placeAddress : placeAddress.substr(0, index);
-        // 空白と「、」以降の文字を削除した文字列
-        document.querySelector('input[name="country"]').value = trimmedAddress;
         // 検索機能やすでにピン立てしている場所をクリックした際にplaceIDを変える
         document.querySelector('input[name="placeID"]').value = placeId;
-        // 住所がある場所の名前をセットする処理
-        document.querySelector('input[name="placeName"]').value = place.name;
+        // 空白以降の文字を削除した文字列
+        document.querySelector('input[name="country"]').value = trimmedAddress;
+        // 取得した住所をformのinputにセットする
+        document.querySelector('input[name="placeName"]').value = placeName;
         // 都道府県検索の表示欄は同期できないので削除する
         document.querySelector('input[name="region"]').value = "";
         // サイドバーからもストリートビューを表示できるようにする関数
         streetLocation(place.coords, widget.map);
         showDetailsPanel(place);
-        // TODO ここまで
       };
 
       widget.fetchPlaceDetails(placeId, [
@@ -604,7 +592,7 @@ function geocodeLatLng(geocoder, map) {
 }
 
 // 場所をクリックすると調べるフォームに飛ぶ
-// TODO function化
+// TODO function化 function addressProcess(result, number)みたいにする
 function clickNoArea(latlng, geocoder) {
   geocoder.geocode({ 'location': latlng }, function(results) {
     let clickAddress;

--- a/static/js/googleMap.js
+++ b/static/js/googleMap.js
@@ -137,11 +137,11 @@ function NeighborhoodDiscovery(configuration) {
     // フルスクリーンになるボタンを右下に配置する
     mapOptions.fullscreenControlOptions = {position: google.maps.ControlPosition.BOTTOM_LEFT};
     mapOptions.rotateControl = true;
-    mapOptions.rotateControlOptions = {position: google.maps.ControlPosition.LEFT_BOTTOM};
+    mapOptions.rotateControlOptions = {position: google.maps.ControlPosition.RIGHT_BOTTOM};
     // ストリートビューが使えるボタンを左に配置する
     mapOptions.streetViewControlOptions = {position: google.maps.ControlPosition.LEFT_BOTTOM};
-    // ズームボタンを右下に配置する
-    mapOptions.zoomControlOptions = {position: google.maps.ControlPosition.RIGHT_BOTTOM};
+    // ズームボタンを非表示する
+    mapOptions.zoomControl = false;
     mapOptions.scaleControl = true;
     mapOptions.scaleControlOptions = {position: google.maps.ControlPosition.LEFT};
     // 地図のタイプ(航空写真+ラベル付き)

--- a/templates/map.html
+++ b/templates/map.html
@@ -28,7 +28,7 @@
           ],
           "mapRadius": 9999999,
           // 初期の位置設定
-          "mapOptions": {"center":{"lat":35.6761919,"lng":139.6503106},"streetViewControl":true,"zoom":5,"maxZoom":20,"mapId":""/** スタイルを変えられる処理 */},
+          "mapOptions": {"center":{"lat":35.6761919,"lng":139.6503106},"zoom":5,"maxZoom":25,"mapId":""/** スタイルを変えられる処理 */},
           "mapsApiKey": "{{ google_maps_api_key }}",
         };
 
@@ -121,36 +121,6 @@
 {% endblock %}
 
 {% block main %}
-<main class="container-fluid py-5 text-center">
-  <div class="flex flex-col md:flex-row">
-    <div class="md:w-1/2">
-      <h1 class="mt-1 text-lg font-semibold text-black sm:text-slate-900 md:text-2xl dark:sm:text-white py-3 px-4 pr-9">現在、【<span id="searchTypeText" class="mt-1 text-lg font-semibold text-black sm:text-slate-900 md:text-2xl dark:sm:text-white">国</span>】単位で検索中です</h1>
-      <!-- このコードはないものとしてください -->
-      <input id="latlng" type="text" value="{{ locations }}" hidden />
-      <div>
-        <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" id="countryBtn" onclick="changeSearchType('country')">国単位</button>
-        <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" id="prefectureBtn" onclick="changeSearchType('prefecture')">県単位</button>
-        <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" id="cityBtn" onclick="changeSearchType('city')">市単位</button>
-        <form action="/region_info" method="get">
-          <div class="mt-3">
-              <input class="form-control mx-auto w-auto mb-3" name="region" placeholder="入力" type="text" value="{{ nation_name }}">
-              <input class="form-control mx-auto w-auto mb-3" name="placeID" placeholder="入力" type="text" hidden>
-          </div>
-          <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" type="submit">調べる</button>
-        </form>
-      </div>
-    </div>
-    <div class="md:w-1/2">
-      <h1 class="mt-1 text-lg font-semibold text-black sm:text-slate-900 md:text-2xl dark:sm:text-white py-3 px-4 pr-9">場所で検索中です</h1>
-      <form action="/region_info" method="get">
-        <div>
-            <input class="form-control mx-auto w-auto mb-3" name="placeName" placeholder="入力" type="text">
-        </div>
-        <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" type="submit">調べる</button>
-      </form>
-    </div>
-  </div>
-</main>
 <div class="neighborhood-discovery">
   <div class="places-panel panel no-scroll">
     <header class="navbar">
@@ -187,5 +157,34 @@
     <path d="M13 0C5.817 0 0 5.93 0 13.267c0 7.862 5.59 10.81 9.555 17.624C12.09 35.248 11.342 38 13 38c1.723 0 .975-2.817 3.445-7.043C20.085 24.503 26 21.162 26 13.267 26 5.93 20.183 0 13 0Z"/>
   </svg>
 </div>
-
+<main class="container-fluid py-5 text-center">
+  <div class="flex flex-col md:flex-row">
+    <div class="md:w-1/2">
+      <h1 class="mt-1 text-lg font-semibold text-black sm:text-slate-900 md:text-2xl dark:sm:text-white py-3 px-4 pr-9">現在、【<span id="searchTypeText" class="mt-1 text-lg font-semibold text-black sm:text-slate-900 md:text-2xl dark:sm:text-white">国</span>】単位で検索中です</h1>
+      <!-- このコードはないものとしてください -->
+      <input id="latlng" type="text" value="{{ locations }}" hidden />
+      <div>
+        <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" id="countryBtn" onclick="changeSearchType('country')">国単位</button>
+        <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" id="prefectureBtn" onclick="changeSearchType('prefecture')">県単位</button>
+        <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" id="cityBtn" onclick="changeSearchType('city')">市単位</button>
+        <form action="/region_info" method="get">
+          <div class="mt-3">
+              <input class="form-control mx-auto w-auto mb-3" name="region" placeholder="入力" type="text" value="{{ nation_name }}">
+              <input class="form-control mx-auto w-auto mb-3" name="placeID" placeholder="入力" type="text" hidden>
+          </div>
+          <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" type="submit">調べる</button>
+        </form>
+      </div>
+    </div>
+    <div class="md:w-1/2">
+      <h1 class="mt-1 text-lg font-semibold text-black sm:text-slate-900 md:text-2xl dark:sm:text-white py-3 px-4 pr-9">場所で検索中です</h1>
+      <form action="/region_info" method="get">
+        <div>
+            <input class="form-control mx-auto w-auto mb-3" name="placeName" placeholder="入力" type="text">
+        </div>
+        <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" type="submit">調べる</button>
+      </form>
+    </div>
+  </div>
+</main>
 {% endblock %}

--- a/templates/map.html
+++ b/templates/map.html
@@ -172,7 +172,7 @@
           <div class="mt-3">
               <input class="form-control mx-auto w-auto mb-3" name="region" placeholder="入力" type="text" value="{{ nation_name }}">
               <input name="placeID" type="text" hidden>
-              <input name="country" type="text">
+              <input name="country" type="text" hidden>
           </div>
           <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" type="submit">調べる</button>
         </form>

--- a/templates/map.html
+++ b/templates/map.html
@@ -21,6 +21,7 @@
             {"placeId": "ChIJ3XYIepA5AWAR-uzxmllSqgg"},
             {"placeId": "ChIJW-T2Wt7Gt4kRKl2I1CJFUsI"},
             {"placeId": "ChIJMaLcFIJZGGARKMQf8vX-Qws"},
+            {"placeId": "ChIJqUFu_8qdWFERkbMg_pPSNSQ"},
             // ここにfor文でPlaceIDを挿入する
             // {% for nation in nations %}
             //   {"placeId": "{{ placeID }}"},
@@ -170,7 +171,8 @@
         <form action="/region_info" method="get">
           <div class="mt-3">
               <input class="form-control mx-auto w-auto mb-3" name="region" placeholder="入力" type="text" value="{{ nation_name }}">
-              <input class="form-control mx-auto w-auto mb-3" name="placeID" placeholder="入力" type="text" hidden>
+              <input name="placeID" type="text" hidden>
+              <input name="country" type="text">
           </div>
           <button class="shadow bg-purple-500 hover:bg-purple-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" type="submit">調べる</button>
         </form>


### PR DESCRIPTION
# Pull Request

関連する issue: #103 #104 

## レビュー担当者を割り当てる前の担当者のチェックリスト

<!-- Only complete tasks that are necessary -->

- [ ] PR を作るときは必ず自分をアサインすること
- [ ] 全ての TODO は完了できているか
- [ ] わかりやすい PR か
- [ ] PR の結果や変更を簡潔にシェアしてください
- [ ] 期限を厳守できたか

<!--
  <details>
    <summary>Example of Audits Report on 11/1/2019</summary>

  copy this [gist](https://gist.github.com/oladhari/ee8b153c2d8001ae6d87f8f9633bce1d) and drop it in this [viewer](https://googlechrome.github.io/lighthouse/viewer/) to read the report
  </details>

  <details>
    <summary>Example of Coverage Report on 11/1/2019</summary>

  </details>
-->

## PR を承認する前のレビュアーのチェックリスト

<!-- Only complete tasks that are necessary -->

- [ ] コードが最も効果的に記載されているか
- [ ] コードがタスクの完了を満たしているか

## 変更の概要

<!-- write summary here -->
mapをクリックする際に、一部の土地の情報を取得できなかった問題を修正
お気に入り登録された地域を国ごとに分けて表示させるための情報を送った
